### PR TITLE
Allow installation without numpy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,6 @@ import os
 from setuptools import find_packages, Extension, setup
 import versioneer
 import glob
-import numpy as np
 
 short_description = __doc__.split("\n")
 fpath = os.path.join("despasito", "equations_of_state", "saft", "compiled_modules")
@@ -15,10 +14,12 @@ extensions = []
 
 try:
     from Cython.Build import cythonize
+    import numpy as np
     flag_cython = True
-except Exception:
+except ImportError as e:
     print(
-        'Cython not available on your system. Dependencies will be run with numba.'
+        'Cython/numpy not available on your system. Dependencies will be run with numba.' \
+        'Original error: ' + str(e)
     )
     flag_cython = False
 


### PR DESCRIPTION
## Description
When installing `despasito`, the user must have `numpy` installed for the import to run. However, if the user does not have Cython installed, `numpy` will not be used anyway.

## Todos
I propose moving the `numpy` import inside the same optional logic as Cython, and modifying the warning to be more explicit.

## Questions
If you like this change, the README should also be updated to explain how `numpy` and Cython are optional for acceleration.

## Status
- [ ] Ready to go

## Note
This PR is part of an ongoing JOSS review at https://github.com/openjournals/joss-reviews/issues/7365